### PR TITLE
Added COREOS support for BVT test cycle.

### DIFF
--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -905,6 +905,8 @@ Function GetAndCheckKernelLogs($DeployedServices, $status)
 				$out = RunLinuxCmd -ip $VMEndpoints[0].Vip -port $VMSSHPort -username $user -password $password -command "dmesg > /home/$user/InitialBootLogs.txt" -runAsSudo
 				$out = RemoteCopy -download -downloadFrom $VMEndpoints[0].Vip -port $VMSSHPort -files "/home/$user/InitialBootLogs.txt" -downloadTo $BootLogDir -username $user -password $password
 				LogMsg "$($VM.Name): $status Kernel logs collected ..SUCCESSFULLY"
+				$detectedDistro = DetectLinuxDistro -VIP $VMEndpoints[0].Vip -SSHport $VMSSHPort -testVMUser $user -testVMPassword $password
+				SetDistroSpecificVariables -detectedDistro $detectedDistro
 				$retValue = $true
 			}
 			elseif($status -imatch "Final")
@@ -958,6 +960,20 @@ Function GetAndCheckKernelLogs($DeployedServices, $status)
 	return $retValue
 }
 
+Function SetDistroSpecificVariables($detectedDistro)
+{
+	if ( $detectedDistro -imatch "COREOS" )
+	{
+		$python_cmd = "/usr/share/oem/python/bin/python"
+		LogMsg "Set `$python_cmd > /usr/share/oem/python/bin/python"
+	}
+	else
+	{
+		$python_cmd = "python"
+		LogMsg "Set `$python_cmd > python"
+	}
+	Set-Variable -Name python_cmd -Value $python_cmd -Scope Global
+}
 
 Function DeployVMs ($xmlConfig, $setupType, $Distro)
 {

--- a/remote-scripts/BVT-HVMODULES-CHECK.ps1
+++ b/remote-scripts/BVT-HVMODULES-CHECK.ps1
@@ -28,7 +28,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-IS-ROOT-PASSWORD-DELETED.ps1
+++ b/remote-scripts/BVT-IS-ROOT-PASSWORD-DELETED.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-LAST-CONSOLE-CHECK.ps1
+++ b/remote-scripts/BVT-LAST-CONSOLE-CHECK.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-MTAB-ENTRY-CHECK.ps1
+++ b/remote-scripts/BVT-MTAB-ENTRY-CHECK.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-RESOURCE-DISK-FILESYSTEM.ps1
+++ b/remote-scripts/BVT-RESOURCE-DISK-FILESYSTEM.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-ROOT-DEVICE-TIMEOUT-CHECK.ps1
+++ b/remote-scripts/BVT-ROOT-DEVICE-TIMEOUT-CHECK.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-SWAP-CHECK.ps1
+++ b/remote-scripts/BVT-SWAP-CHECK.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-BOOT-ERROR-WARNINGS.ps1
+++ b/remote-scripts/BVT-VERIFY-BOOT-ERROR-WARNINGS.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-DISKSIZE.ps1
+++ b/remote-scripts/BVT-VERIFY-DISKSIZE.ps1
@@ -31,7 +31,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript) -e $OsImageSizeKB" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript) -e $OsImageSizeKB" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-FIREWALL-STATUS.ps1
+++ b/remote-scripts/BVT-VERIFY-FIREWALL-STATUS.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/$user/state.txt, /home/$user/Summary.log, /home/$user/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-HOSTNAME.ps1
+++ b/remote-scripts/BVT-VERIFY-HOSTNAME.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript) -e $hs1vm1Hostname" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript) -e $hs1vm1Hostname" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-MNT-RESOURCE-WRITABLE.ps1
+++ b/remote-scripts/BVT-VERIFY-MNT-RESOURCE-WRITABLE.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-SSHD-CONFIG.ps1
+++ b/remote-scripts/BVT-VERIFY-SSHD-CONFIG.ps1
@@ -27,7 +27,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		$output=RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "python $($currentTestData.testScript)" -runAsSudo
+		$output=RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/$user/state.txt, /home/$user/Summary.log, /home/$user/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-UUID-FSTAB.ps1
+++ b/remote-scripts/BVT-VERIFY-UUID-FSTAB.ps1
@@ -30,7 +30,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript) -e $hs1vm1Hostname" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript) -e $hs1vm1Hostname" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.ps1
+++ b/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.ps1
@@ -56,7 +56,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		$consoleOut = RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "python $($currentTestData.testScript) -d $detectedDistro" -runAsSudo
+		$consoleOut = RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript) -d $detectedDistro" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/$user/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$errorCount = 0

--- a/remote-scripts/BVT-WA-PROC-CHECK.ps1
+++ b/remote-scripts/BVT-WA-PROC-CHECK.ps1
@@ -29,7 +29,7 @@ if ($isDeployed)
 
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log

--- a/remote-scripts/BVT-WA-VER-CHECK.ps1
+++ b/remote-scripts/BVT-WA-VER-CHECK.ps1
@@ -28,7 +28,7 @@ if ($isDeployed)
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "chmod +x *" -runAsSudo
 
 		LogMsg "Executing : $($currentTestData.testScript)"
-		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "./$($currentTestData.testScript)" -runAsSudo
+		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "$python_cmd $($currentTestData.testScript)" -runAsSudo
 		RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "mv Runtime.log $($currentTestData.testScript).log" -runAsSudo
 		RemoteCopy -download -downloadFrom $hs1VIP -files "/home/test/state.txt, /home/test/Summary.log, /home/test/$($currentTestData.testScript).log" -downloadTo $LogDir -port $hs1vm1sshport -username $user -password $password
 		$testResult = Get-Content $LogDir\Summary.log


### PR DESCRIPTION
Know issues : 

a.	BVT-LAST-CONSOLE-CHECK
This test is failing with error : “console=ttys0 is not present”
Manual Verification : “console=ttyS0” is present (only a lower case / upper case letter issue.)
Resolution : Test case needs to be updated
b.	BVT-VERIFY-VHD-PREREQUISITES
Currently this test does not have any code related to checks in CoreOS. 
Resolution : CoreOS related checks needs to be added in BVT-VERIFY-VHD-PREREQUISITES.py file
c.	BVT-WA-VER-CHECK
This test case is failing due to BVT-WA-VER-CHECK.py is trying to execute “waagent --version”.
Resolution : As python is not in the $PATH of CoreOS, so we need to push full python path in BVT-WA-VER-CHECK.py file.

I'll fix above issues in next commit.