### PR TITLE
Fixes for VNET cases, SLES/SUSE and CoreOS

### DIFF
--- a/Documentation/Azure VNET automation/CONFIGURE-VNET-DNS-SERVER.txt
+++ b/Documentation/Azure VNET automation/CONFIGURE-VNET-DNS-SERVER.txt
@@ -1,7 +1,7 @@
 Configure DNS server with newly deployed Virtual Machine details.
 	1.	Get the DIPs of all deployed VM's.
 	2.	Login to one of the deployed VM and from there, SSH into DNS SERVER.
-	3.	edit file : /etc/bind/zones/lisvnet.com.db
+	3.	edit file : /etc/bind/zones/lisvnetlab.com.db
 		a.	Add (Append) each VM's DIP and HOSTNAME details here in following format.
 			VM1_hostname    IN      A       VM1_DIP
 			VM2_hostname    IN      A       VM2_DIP

--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -1951,7 +1951,16 @@ Function DoTestCleanUp($result, $testName, $DeployedServices, $setupType = "BVTD
                 Remove-Job -Id $taskID -Force
             }
 			$user=$xmlConfig.config.Azure.Deployment.Data.UserName
-			$KernelLogOutput=GetAndCheckKernelLogs -DeployedServices $deployedServices -status "Final" #Collecting kernel logs after execution of test case : v-sirebb
+			try
+			{
+				$KernelLogOutput=GetAndCheckKernelLogs -DeployedServices $deployedServices -status "Final" #Collecting kernel logs after execution of test case : v-sirebb
+			}
+			catch 
+			{
+				$ErrorMessage =  $_.Exception.Message
+				LogMsg "EXCEPTION in GetAndCheckKernelLogs(): $ErrorMessage"	
+			}
+			
 			$isClened = @()
 			$hsNames = $DeployedServices
 			$hsNames = $hsNames.Split("^")

--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -996,6 +996,12 @@ Function SetDistroSpecificVariables($detectedDistro)
     $python_cmd = "python"
 	LogMsg "Set `$python_cmd > python"    
 	Set-Variable -Name python_cmd -Value $python_cmd -Scope Global
+	Set-Variable -Name ifconfig_cmd -Value "ifconfig" -Scope Global
+	if($detectedDistro -eq "SLES" -or $detectedDistro -eq "SUSE" )
+	{
+		Set-Variable -Name ifconfig_cmd -Value "/sbin/ifconfig" -Scope Global
+		LogMsg "Set `$ifconfig_cmd > $ifconfig_cmd for $detectedDistro"
+	}
 }
 
 Function DeployVMs ($xmlConfig, $setupType, $Distro, $getLogsIfFailed = $false)
@@ -3980,7 +3986,7 @@ Function VerifyDIPafterInitialDeployment($DeployedServices)
 
 			$VMEndpoints = Get-AzureEndpoint -VM $VM
 			$VMSSHPort = GetPort -Endpoints $VMEndpoints -usage "SSH"
-			$out = RunLinuxCmd -ip $VMEndpoints[0].Vip -port $VMSSHPort -username $user -password $password -command "ifconfig -a" -runAsSudo
+			$out = RunLinuxCmd -ip $VMEndpoints[0].Vip -port $VMSSHPort -username $user -password $password -command "$ifconfig_cmd -a" -runAsSudo
 			if ($out -imatch $VM.IpAddress)
 			{
 				LogMsg "Expected DIP : $($VM.IpAddress); Recorded DIP : $($VM.IpAddress);"

--- a/remote-scripts/BVT-VERIFY-SHUTDOWN.ps1
+++ b/remote-scripts/BVT-VERIFY-SHUTDOWN.ps1
@@ -37,7 +37,9 @@ if ($isDeployed)
 			LogErr "Virtual machine shut down failed."
 			$testResult = "FAIL"
 		}
-
+		
+		LogMsg "Boot $hs1vm1Hostname after test complete ..."
+		startAllDeployments -DeployedServices $isDeployed
 	}
 
 	catch

--- a/remote-scripts/BVT-VERIFY-SHUTDOWN.ps1
+++ b/remote-scripts/BVT-VERIFY-SHUTDOWN.ps1
@@ -37,9 +37,6 @@ if ($isDeployed)
 			LogErr "Virtual machine shut down failed."
 			$testResult = "FAIL"
 		}
-		
-		LogMsg "Boot $hs1vm1Hostname after test complete ..."
-		startAllDeployments -DeployedServices $isDeployed
 	}
 
 	catch

--- a/remote-scripts/VNET-PING-LOCAL-TO-VNET-ACCESS.ps1
+++ b/remote-scripts/VNET-PING-LOCAL-TO-VNET-ACCESS.ps1
@@ -152,13 +152,13 @@ if($isDeployed)
 
 					if(($mode -eq "IP") -or ($mode -eq "VIP") -or ($mode -eq "DIP"))
 					{
-						Write-Host $VnetTestIP
+						Write-Host $TestVMIP
 						$pingFrom.cmd = "python /home/$user/ping.py -x $TestVMIP -c 10"
 					}
 
 					if(($mode -eq "URL") -or ($mode -eq "Hostname"))
 					{
-						Write-Host $VnetTestHostName
+						Write-Host $TestVMHostname
 						$pingFrom.cmd = "python /home/$user/ping.py -x $TestVMHostname  -c 10"
 					}
 					LogMsg "Test Started for $Value in $mode mode.."

--- a/remote-scripts/VNET-PING-VNET-TO-LOCAL-ACCESS.ps1
+++ b/remote-scripts/VNET-PING-VNET-TO-LOCAL-ACCESS.ps1
@@ -164,13 +164,13 @@ if($isDeployed)
 					if(($mode -eq "IP") -or ($mode -eq "VIP") -or ($mode -eq "DIP"))
 					{
 						Write-Host $VnetTestIP
-						$pingFrom.cmd = "./ping.py -x $($mysqlServer.ip) -c 10"
+						$pingFrom.cmd = "python /home/$user/ping.py -x $($mysqlServer.ip) -c 10"
 					}
 
 					if(($mode -eq "URL") -or ($mode -eq "Hostname"))
 					{
 						Write-Host $VnetTestHostName
-						$pingFrom.cmd = "./ping.py -x $($mysqlServer.hostname)  -c 10"
+						$pingFrom.cmd = "python /home/$user/ping.py -x $($mysqlServer.hostname)  -c 10"
 					}
 					LogMsg "Test Started for $Value in $mode mode.."
 

--- a/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-INTERVNET-ACCESS.ps1
+++ b/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-INTERVNET-ACCESS.ps1
@@ -158,14 +158,14 @@ if($isDeployed)
 
 					if(($mode -eq "IP") -or ($mode -eq "VIP") -or ($mode -eq "DIP"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py"
 
 					}
 
 					if(($mode -eq "URL") -or ($mode -eq "Hostname"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo -hostnameMode
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo -hostnameMode
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py" -hostnameMode
 					}
 					LogMsg "SSH result : $sshResult"

--- a/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-INTRAVNET-ACCESS.ps1
+++ b/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-INTRAVNET-ACCESS.ps1
@@ -114,13 +114,13 @@ if($isDeployed)
 
 					if(($mode -eq "IP") -or ($mode -eq "VIP") -or ($mode -eq "DIP"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py"
 
 					}
 					if(($mode -eq "URL") -or ($mode -eq "Hostname"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo -hostnameMode
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo -hostnameMode
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py" -hostnameMode
 					}
 					LogMsg "SSH result : $sshResult"

--- a/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-LOCAL-TO-VNET-ACCESS.ps1
+++ b/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-LOCAL-TO-VNET-ACCESS.ps1
@@ -67,8 +67,7 @@ if($isDeployed)
 	try
 	{
 		$dnsServer = CreateVMNode -nodeIp '192.168.3.120' -nodeSshPort 22 -user root -password "redhat" -nodeHostname "ubuntudns"
-		$intermediateVM = CreateVMNode -nodeIp $hs1VIP -nodeSshPort $hs1vm1sshport -user $user -password $password -nodeDip $hs1vm1IP -nodeHostname $hs1vm1Hostname
-		$externalServer = CreateVMNode -nodeIp $externalServerIP -nodeSshPort $externalServerSSHport -user $externalServerUser -password $externalServerPass
+		$intermediateVM = CreateVMNode -nodeIp $hs1VIP -nodeSshPort $hs1vm1sshport -user $user -password $password -nodeDip $hs1vm1IP -nodeHostname $hs1vm1Hostname		
 		ConfigureVNETVms -SSHDetails $SSHDetails
 		UploadFilesToAllDeployedVMs -SSHDetails $SSHDetails -files $currentTestData.files
 		RunLinuxCmdOnAllDeployedVMs -SSHDetails $SSHDetails -command "chmod +x *"
@@ -91,21 +90,19 @@ if($isDeployed)
 		{
 			mkdir $LogDir\$Value -ErrorAction SilentlyContinue | out-null
 
-			$LocalVM = $dnsServer
-
 			switch ($Value)
 			{
 				"HS1VM1" {
-					$ToVM = CreateVMNode -nodeIp $hs1VIP -nodeSshPort $hs1vm1sshport -user $user -password $password -logDir $LogDir -nodeDip $hs1vm1IP -nodeHostname $hs1vm1Hostname
+					$ToVM = CreateVMNode -nodeIp $hs1vm1IP -nodeSshPort $hs1vm1sshport -user $user -password $password -logDir $LogDir -nodeDip $hs1vm1IP -nodeHostname $hs1vm1Hostname
 				}
 				"HS1VM2" {
-					$ToVM = CreateVMNode -nodeIp $hs1VIP -nodeSshPort $hs1vm2sshport -user $user -password $password -logDir $LogDir -nodeDip $hs1vm2IP -nodeHostname $hs1vm2Hostname
+					$ToVM = CreateVMNode -nodeIp $hs1vm2IP -nodeSshPort $hs1vm2sshport -user $user -password $password -logDir $LogDir -nodeDip $hs1vm2IP -nodeHostname $hs1vm2Hostname
 				}
 				"HS2VM1" {
-					$ToVM = CreateVMNode -nodeIp $hs2VIP -nodeSshPort $hs2vm1sshport -user $user -password $password -logDir $LogDir -nodeDip $hs2vm1IP -nodeHostname $hs2vm1Hostname
+					$ToVM = CreateVMNode -nodeIp $hs2vm1IP -nodeSshPort $hs2vm1sshport -user $user -password $password -logDir $LogDir -nodeDip $hs2vm1IP -nodeHostname $hs2vm1Hostname
 				}
 				"HS2VM2" {
-					$ToVM = CreateVMNode -nodeIp $hs2VIP -nodeSshPort $hs2vm2sshport -user $user -password $password -logDir $LogDir -nodeDip $hs2vm2IP -nodeHostname $hs2vm2Hostname
+					$ToVM = CreateVMNode -nodeIp $hs2vm2IP -nodeSshPort $hs2vm2sshport -user $user -password $password -logDir $LogDir -nodeDip $hs2vm2IP -nodeHostname $hs2vm2Hostname
 				}
 			}
 			foreach ($mode in $currentTestData.TestMode.Split(","))

--- a/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-OUTBOUND-ACCESS.ps1
+++ b/remote-scripts/VNET-VERIFY-REMOTE-SSH-SCP-OUTBOUND-ACCESS.ps1
@@ -141,14 +141,14 @@ if($isDeployed)
 
 					if(($mode -eq "IP") -or ($mode -eq "VIP") -or ($mode -eq "DIP"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py"
 
 					}
 
 					if(($mode -eq "URL") -or ($mode -eq "Hostname"))
 					{
-						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "ifconfig" -runAsSudo -hostnameMode
+						$sshResult = DoSSHTest -fromVM $FromVM -toVM $ToVM -command "$ifconfig_cmd" -runAsSudo -hostnameMode
 						$scpResult = DoSCPTest -fromVM $FromVM -toVM $ToVM -filesToCopy "/home/$user/azuremodules.py" -hostnameMode
 					}
 					LogMsg "SSH result : $sshResult"

--- a/remote-scripts/ignorable-boot-errors.xml
+++ b/remote-scripts/ignorable-boot-errors.xml
@@ -66,7 +66,6 @@
 			<keywords>failsafe</keywords>
 			<keywords>startpar-bridge</keywords>
 			<keywords>Failed to spawn</keywords>
-			<keywords>user@1000.service</keywords>
 		</failures>
 		<errors>
 			<keywords>Broken pipe</keywords>


### PR DESCRIPTION
1. Correct logic of VNET-VERIFY-REMOTE-SSH-SCP-LOCAL-TO-VNET-ACCESS, VNET-PING-VNET-TO-LOCAL-ACCESS, VNET-PING-LOCAL-TO-VNET-ACCESS.
2. Update VNET cases for CoreOS.
3. Catch exception when collect kernel log.
4. Fix ifconfig not found issue on SLES and SUSE.
5. Update ignorable boot error for Ubuntu.