### PR TITLE
fix issue that throw null-valued exception sometimes

### DIFF
--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -1682,6 +1682,7 @@ Function RunLinuxCmd([string] $username,[string] $password,[string] $ip,[string]
 		-ArgumentList $currentDir, $username, $password, $ip, $port, $linuxCommand
 		$RunLinuxCmdOutput = ""
 		$debugOutput = ""
+		$LinuxExitCode = ""
         
 		if ( $RunInBackGround )
 		{


### PR DESCRIPTION
fix issue that throw the following exception sometimes:                                                                   EXCEPTION : You cannot call a method on a null-valued expression