### PR TITLE
Add fqdn verification to BVT

### DIFF
--- a/Azure_ICA_all.xml
+++ b/Azure_ICA_all.xml
@@ -2260,7 +2260,7 @@
 			<testName>BVT-VERIFY-DEPLOYMENT-PROVISION</testName>
 			<testScript></testScript>
 			<testScriptPs1>BVT-VERIFY-DEPLOYMENT-PROVISION.ps1</testScriptPs1>
-			<files></files>
+			<files>.\remote-scripts\nslookup.py</files>
 			<setupType>BVTDeployment</setupType>
 			<TestType></TestType>
 			<TestFeature></TestFeature>

--- a/Azure_ICA_all.xml
+++ b/Azure_ICA_all.xml
@@ -2260,7 +2260,7 @@
 			<testName>BVT-VERIFY-DEPLOYMENT-PROVISION</testName>
 			<testScript></testScript>
 			<testScriptPs1>BVT-VERIFY-DEPLOYMENT-PROVISION.ps1</testScriptPs1>
-			<files>.\remote-scripts\nslookup.py</files>
+			<files></files>
 			<setupType>BVTDeployment</setupType>
 			<TestType></TestType>
 			<TestFeature></TestFeature>
@@ -2271,7 +2271,7 @@
 			<testName>BVT-VERIFY-HOSTNAME</testName>
 			<testScript>BVT-VERIFY-HOSTNAME.py</testScript>
 			<testScriptPs1>BVT-VERIFY-HOSTNAME.ps1</testScriptPs1>
-			<files>.\remote-scripts\BVT-VERIFY-HOSTNAME.py,.\remote-scripts\azuremodules.py</files>
+			<files>.\remote-scripts\nslookup.py,.\remote-scripts\BVT-VERIFY-HOSTNAME.py,.\remote-scripts\azuremodules.py</files>
 			<setupType>BVTDeployment</setupType>
 			<TestType></TestType>
 			<TestFeature></TestFeature>

--- a/remote-scripts/BVT-VERIFY-HOSTNAME.py
+++ b/remote-scripts/BVT-VERIFY-HOSTNAME.py
@@ -6,6 +6,7 @@ from azuremodules import *
 import argparse
 import sys
 import time
+import re
         #for error checking
 parser = argparse.ArgumentParser()
 
@@ -17,16 +18,36 @@ expectedHostname = args.expected
 
 def RunTest(expectedHost):
     UpdateState("TestRunning")
-    RunLog.info("Checking hostname...")
-    temp = Run("hostname")
-    output = temp
-    if (expectedHost in output) :
-        RunLog.info('Hostname is set successfully to %s' %expectedHost)
+    if CheckHostName(expectedHost) and CheckFQDN(expectedHost):
         ResultLog.info('PASS')
         UpdateState("TestCompleted")
-    else :
-        RunLog.error('Hostname change failed. Current hostname : %s Expected hostname : %s' % (output, expectedHost))
+    else:
         ResultLog.error('FAIL')
         UpdateState("TestCompleted")
+
+def CheckHostName(expectedHost):
+    RunLog.info("Checking hostname...")
+    output = Run("hostname")
+    if expectedHost in output:
+        RunLog.info('Hostname is set successfully to {0}'.format(expectedHost))
+        return True
+    else:
+        RunLog.error('Hostname change failed. Current hostname : {0} Expected hostname : {1}'.format(output, expectedHost))
+        return False
+
+def CheckFQDN(expectedHost):
+    RunLog.info("Checking fqdn...")
+    [current_distro, distro_version] = DetectDistro()
+    nslookupCmd = "nslookup {0}".format(expectedHost)
+    if current_distro == 'coreos':
+        nslookupCmd = "python nslookup.py -n {0}".format(expectedHost)
+    output = Run(nslookupCmd)
+    if re.search("server can't find", output) is None:
+        RunLog.info('nslookup successfully for: {0}'.format(expectedHost))
+        return True
+    else:
+        RunLog.error("nslookup failed for: {0}, {1}".format(expectedHost, output))
+        return False
+
 
 RunTest(expectedHostname)


### PR DESCRIPTION
Tested with centos

11/06/2015 09:05:42 AM : INFO : Checking hostname...
11/06/2015 09:05:42 AM : DEBUG : ICA-HS-BVTDeployment-CI-CENTOS71-YZ212RC2-11-6-0-55-26-role-0

11/06/2015 09:05:42 AM : INFO : Hostname is set successfully to ICA-HS-BVTDeployment-CI-CENTOS71-YZ212RC2-11-6-0-55-26-role-0
11/06/2015 09:05:42 AM : INFO : Checking fqdn...
11/06/2015 09:05:42 AM : INFO : Detecting Distro 
11/06/2015 09:05:42 AM : DEBUG : CentOS Linux release 7.1.1503 (Core) 
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

CentOS Linux release 7.1.1503 (Core) 
CentOS Linux release 7.1.1503 (Core) 

11/06/2015 09:05:42 AM : DEBUG : Server:		100.74.116.50
Address:	100.74.116.50#53

Name:	ICA-HS-BVTDeployment-CI-CENTOS71-YZ212RC2-11-6-0-55-26-role-0.ICA-HS-BVTDeployment-CI-CENTOS71-YZ212RC2-11-6-0-55-26.d3.internal.cloudapp.net
Address: 100.74.116.82


11/06/2015 09:05:42 AM : INFO : nslookup successfully for: ICA-HS-BVTDeployment-CI-CENTOS71-YZ212RC2-11-6-0-55-26-role-0
