### PR TITLE
BVT-VERIFY-VHD-PREREQUISITES

### DIFF
--- a/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
+++ b/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
@@ -59,7 +59,7 @@ def verify_grub(distro):
 		grub_out = Run("dmesg")
 	if "console=ttyS0" in grub_out and "rootdelay=300" in grub_out and "libata.atapi_enabled=0" not in grub_out and "reserve=0x1f0,0x8" not in grub_out:
 		if distro == "ORACLELINUX" or distro == "REDHAT":
-			# check numa=off in grub for CentOS 6.x and Oracle Linux 6.x
+			# check numa=off in grub for RedHat 6.x and Oracle Linux 6.x
 			version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
 			if float(version_release) < 7.0:
 				if "numa=off" in grub_out:
@@ -73,7 +73,7 @@ def verify_grub(distro):
 			print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
 			return True
 		if distro == "CENTOS":
-			# check numa=off in grub for CentOS 6.x and Oracle Linux 6.x
+			# check numa=off in grub for CentOS 6.x
 			version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
 			if float(version_release) < 6.6:
 				if "numa=off" in grub_out:

--- a/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
+++ b/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
@@ -58,10 +58,24 @@ def verify_grub(distro):
 		#in core os we don't have access to boot partition
 		grub_out = Run("dmesg")
 	if "console=ttyS0" in grub_out and "rootdelay=300" in grub_out and "libata.atapi_enabled=0" not in grub_out and "reserve=0x1f0,0x8" not in grub_out:
-		if distro == "CENTOS" or distro == "ORACLELINUX" or distro == "REDHAT":
+		if distro == "ORACLELINUX" or distro == "REDHAT":
 			# check numa=off in grub for CentOS 6.x and Oracle Linux 6.x
 			version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
 			if float(version_release) < 7.0:
+				if "numa=off" in grub_out:
+					print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
+				else : 
+					RunLog.error("numa=off not present in etc/default/grub")
+					print(distro+"_TEST_GRUB_VERIFICATION_FAIL")
+			else:
+				print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
+		else:
+			print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
+			return True
+		if distro == "CENTOS":
+			# check numa=off in grub for CentOS 6.x and Oracle Linux 6.x
+			version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
+			if float(version_release) < 6.6:
 				if "numa=off" in grub_out:
 					print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
 				else : 
@@ -276,7 +290,7 @@ if distro == "CENTOS":
 	y_out = Run("cat /etc/yum.conf")
 	# check http_caching=packages in yum.conf for CentOS 6.x
 	version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
-	if float(version_release) < 7.0:
+	if float(version_release) < 6.6:
 		if "http_caching=packages" in y_out:
 			RunLog.info("http_caching=packages present in /etc/yum.conf")
 			print(distro+"_TEST_YUM_CONF_SUCCESS")


### PR DESCRIPTION
Make the check for numa=off optional for CentOS 6.6+, and http_caching=packages optional for CentOS