### PR TITLE
Make the check for numa=off optional for CentOS 6.6+, and http_cachin…

### DIFF
--- a/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
+++ b/remote-scripts/BVT-VERIFY-VHD-PREREQUISITES.py
@@ -61,7 +61,7 @@ def verify_grub(distro):
 		if distro == "CENTOS" or distro == "ORACLELINUX" or distro == "REDHAT":
 			# check numa=off in grub for CentOS 6.x and Oracle Linux 6.x
 			version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
-			if float(version_release) < 7.0:
+			if float(version_release) < 6.6:
 				if "numa=off" in grub_out:
 					print(distro+"_TEST_GRUB_VERIFICATION_SUCCESS")
 				else : 
@@ -276,7 +276,7 @@ if distro == "CENTOS":
 	y_out = Run("cat /etc/yum.conf")
 	# check http_caching=packages in yum.conf for CentOS 6.x
 	version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
-	if float(version_release) < 7.0:
+	if float(version_release) < 6.6:
 		if "http_caching=packages" in y_out:
 			RunLog.info("http_caching=packages present in /etc/yum.conf")
 			print(distro+"_TEST_YUM_CONF_SUCCESS")
@@ -317,13 +317,16 @@ if distro == "REDHAT" or distro == "FEDORA":
 
 
 	#Verify etc/yum.conf
-	y_out = Run("cat /etc/yum.conf")
-	if "http_caching=packages" in y_out:
-		RunLog.info("http_caching=packages present in /etc/yum.conf")
-		print(distro+"_TEST_YUM_CONF_SUCCESS")
+	version_release = Run("cat /etc/system-release | grep -Eo '[0-9].?[0-9]?' | head -1 | tr -d '\n'")
+	if float(version_release) < 6.6:
+		if "http_caching=packages" in y_out:
+			RunLog.info("http_caching=packages present in /etc/yum.conf")
+			print(distro+"_TEST_YUM_CONF_SUCCESS")
+		else:
+			RunLog.error("http_caching=packages not present in /etc/yum.conf")
+			print(distro+"_TEST_YUM_CONF_ERROR")
 	else:
-		RunLog.error("http_caching=packages not present in /etc/yum.conf")
-		print(distro+"_TEST_YUM_CONF_ERROR")
+		print(distro+"_TEST_YUM_CONF_SUCCESS")
 	result = verify_grub(distro)
 
 if distro == "ORACLELINUX":


### PR DESCRIPTION
…g=packages optional for CentOS, in case BVT-VERIFY-VHD-PREREQUISITES.