### PR TITLE
Reduce retry count for Docker extension test

### DIFF
--- a/remote-scripts/ICA-DOCKER-EXTENSION-TEST.ps1
+++ b/remote-scripts/ICA-DOCKER-EXTENSION-TEST.ps1
@@ -51,7 +51,7 @@ if ($isDeployed)
 		if ($LogFilesPaths)
 		{   
 			$retryCount = 1
-			$maxRetryCount = 50
+			$maxRetryCount = 20
 			do
 			{   LogMsg "Attempt : $retryCount/$maxRetryCount : Checking extension log files...."
 				foreach ($file in $LogFilesPaths.Split(","))


### PR DESCRIPTION
Failing tests take too much time with 50 retries. If the test is failing after 20 retries it is unlikely to succeed eventually.