### PR TITLE
Fix issues

### DIFF
--- a/remote-scripts/SETUP-INSTALL-PACKAGES.py
+++ b/remote-scripts/SETUP-INSTALL-PACKAGES.py
@@ -28,6 +28,8 @@ def set_variables_OS_dependent():
         global distro_version
         global startup_file
         global python_cmd
+        global waagent_cmd
+        global waagent_bin_path
 
         RunLog.info ("\nset_variables_OS_dependent ..")
         [current_distro, distro_version] = DetectDistro()

--- a/remote-scripts/azuremodules.py
+++ b/remote-scripts/azuremodules.py
@@ -190,9 +190,10 @@ def GetResourceDiskMountPoint():
 
 def RunGetOutput(cmd):
     try:
-        output = subprocess.check_output(cmd,
-                                         stderr=subprocess.STDOUT,
-                                         shell=True)
+        proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+        retval = proc.communicate()
+        output = retval[0]
+
         output = unicode(output,
                          encoding='utf-8',
                          errors="backslashreplace")


### PR DESCRIPTION
Fix below issues:
Issue#1 Add waagent_cmd  waagent_bin_path into global parameters
Issue#2 subprocess.check_output() doesn't seem to exist (Python 2.6.*)
