### PR TITLE
Fix permission denied error in case the user may have no read permission to access the file to be downloaded

### DIFF
--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -2043,6 +2043,13 @@ Function RemoteCopy($uploadTo, $downloadFrom, $downloadTo, $port, $files, $usern
 				$recurse = ""
 				while($retry -le $maxRetry)
 				{
+					if ( $username -ne "root" )
+					{
+						$chown_cmd = "chown -Rf ${username}:${username} $testFile"
+						LogMsg("$chown_cmd")
+						$out = RunLinuxCmd -username $username -password $password -ip $downloadFrom -port $port -command "$chown_cmd" -runAsSudo
+					}
+
 					if($usePrivateKey)
 					{
 						LogMsg "Downloading $testFile from $username : $downloadFrom,port $port to $downloadTo using PrivateKey authentication"

--- a/TestLibs/RDFELibs.psm1
+++ b/TestLibs/RDFELibs.psm1
@@ -2046,7 +2046,7 @@ Function RemoteCopy($uploadTo, $downloadFrom, $downloadTo, $port, $files, $usern
 					if ( $username -ne "root" )
 					{
 						$chown_cmd = "chown -Rf ${username}:${username} $testFile"
-						LogMsg("$chown_cmd")
+						LogMsg "$chown_cmd"
 						$out = RunLinuxCmd -username $username -password $password -ip $downloadFrom -port $port -command "$chown_cmd" -runAsSudo
 					}
 

--- a/remote-scripts/BVT-VERIFY-HOSTNAME.py
+++ b/remote-scripts/BVT-VERIFY-HOSTNAME.py
@@ -28,7 +28,7 @@ def RunTest(expectedHost):
 def CheckHostName(expectedHost):
     RunLog.info("Checking hostname...")
     output = Run("hostname")
-    if expectedHost in output:
+    if expectedHost.lower() in output.lower():
         RunLog.info('Hostname is set successfully to {0}'.format(expectedHost))
         return True
     else:

--- a/remote-scripts/NETWORK-IDNS-SINGLEHS-CHANGED-HOSTNAME.ps1
+++ b/remote-scripts/NETWORK-IDNS-SINGLEHS-CHANGED-HOSTNAME.ps1
@@ -65,8 +65,8 @@ if($isDeployed)
 				$vm2Default = $vm2
 				$vm1DefaultHostname =  $hs1vm1Hostname
 				$vm2DefaultHostname = $hs1vm2Hostname
-				$vm1NewFqdn = $vm1DefaultFqdn.Replace($vm1DefaultHostname, $hs1vm1NewHostname) 
-				$vm2NewFqdn = $vm2DefaultFqdn.Replace($vm2DefaultHostname, $hs1vm2NewHostname) 
+				$vm1NewFqdn = $vm1DefaultFqdn.ToLower().Replace($vm1DefaultHostname.ToLower(), $hs1vm1NewHostname) 
+				$vm2NewFqdn = $vm2DefaultFqdn.ToLower().Replace($vm2DefaultHostname.ToLower(), $hs1vm2NewHostname) 
 			}
 			$out = RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm1sshport -command "rm -rf *.txt *.log" -runAsSudo 
 			$out = RunLinuxCmd -username $user -password $password -ip $hs1VIP -port $hs1vm2sshport -command "rm -rf *.txt *.log" -runAsSudo 


### PR DESCRIPTION
For EulerOS, the default umask value is 077, hence the non-root user doesn't have read permission to access the log files which is generated by the commands runAsSudo in the Guest OS.
The fix will change the owner of the files to the user before downloading.